### PR TITLE
Correct logo alignment in playback area for SD displays.

### DIFF
--- a/components/PodcastScene.xml
+++ b/components/PodcastScene.xml
@@ -102,7 +102,7 @@
 					width = "150"
 					loadWidth = "640"
 					loadHeight = "360"
-					translation = "[42,0]"
+					translation = "[64,0]"
 				/>
 				<Rectangle
 					id = "TimeBarBack"

--- a/manifest
+++ b/manifest
@@ -14,7 +14,7 @@ title=Bad Voltage
 subtitle=Tasty stuff for your ears
 major_version=1
 minor_version=0
-build_version=6
+build_version=7
 
 # Channel Assets
 #   - mm_icon_focus_hd: 336 x 210


### PR DESCRIPTION
Following certification of the Ubuntu Podcast Roku channel there was one finding. The logo in the playback area is slightly offset outside the displayable screen area on Sd displays.

This pull request should fix that.
